### PR TITLE
DOCS: Update documentation to reflect current project state

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,21 +1,19 @@
 # EEMT Algorithm Suite
 
-[![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE)
+[![License](https://img.shields.io/badge/license-BSD%203--Clause-blue.svg)](LICENSE)
 [![Docker](https://img.shields.io/badge/docker-supported-blue.svg)](docker/)
 [![Documentation](https://img.shields.io/badge/docs-mkdocs-blue.svg)](docs/)
-[![Version](https://img.shields.io/badge/version-2.0.0-green.svg)](RELEASE_NOTES.md)
+[![Version](https://img.shields.io/badge/version-2.0.0-green.svg)](.)
 
 The **Effective Energy and Mass Transfer (EEMT) Algorithm Suite** is a comprehensive geospatial modeling toolkit for calculating energy flux in the Critical Zone using topographic solar radiation modeling and climate data integration.
 
-## 🎉 Recent Major Improvements (January 2025)
+## Recent Modernization (2026)
 
-- ✅ **Fixed Web Interface Workflow Submission**: Resolved JSON parsing errors and container preparation hanging issues
-- ✅ **Enhanced System Resource Detection**: Now accurately detects and displays system CPU/memory (255 cores, 1TB RAM on gpu06)
-- ✅ **Improved Container Reliability**: Rebuilt containers with enhanced orchestration and resource management
-- ✅ **Real-time Progress Tracking**: Fixed monitoring dashboard with accurate 0-100% progress updates
-- ✅ **Better Error Handling**: Enhanced error messages and recovery mechanisms throughout the system
-
-[View Full Release Notes](RELEASE_NOTES.md)
+- Migrated from deprecated `r.sun.mp` to GRASS GIS core `r.sun` with `nprocs` parameter
+- Standardized on Python 3.11 for CCTools compatibility
+- Removed legacy Singularity container definitions and deprecated workflow launchers
+- Docker-based deployment with FastAPI web interface and real-time monitoring
+- Automated job cleanup system with configurable retention policies
 
 ## 🚀 Quick Start
 
@@ -24,7 +22,7 @@ Get up and running in under 5 minutes:
 
 ```bash
 # 1. Clone repository
-git clone https://github.com/cyverse-gis/eemt.git
+git clone https://github.com/tyson-swetnam/eemt.git
 cd eemt
 
 # 2. Start with Docker Compose (auto-builds containers)
@@ -112,14 +110,11 @@ EEMT quantifies energy flux in the Critical Zone by combining:
 - **[Web Interface Guide](web-interface/README.md)**: FastAPI interface documentation  
 - **[Algorithm Details](EEMT.md)**: Scientific background and methodology
 - **[Distributed Deployment](docs/distributed-deployment/)**: Multi-node setup guide
-- **[Development Plan](PLAN.md)**: Modernization roadmap
-- **[Workflow Plan](WORKFLOW_PLAN.md)**: Container execution architecture
-
 ## 🔧 Installation
 
 ### Prerequisites
 - **Docker**: Version 20.0+ with daemon running
-- **Python 3.8+**: For web interface dependencies
+- **Python 3.11+**: For web interface dependencies
 - **4GB+ RAM**: 8GB+ recommended for larger DEMs
 - **20GB+ Disk**: For container images and workflow outputs
 
@@ -205,7 +200,7 @@ curl -X POST "http://127.0.0.1:5000/api/submit-job" \
 
 ## 📄 License
 
-This project is licensed under the Apache License 2.0 - see the [LICENSE](LICENSE) file for details.
+This project is licensed under the BSD 3-Clause License - see the [LICENSE](LICENSE) file for details.
 
 ## 📚 Citations
 
@@ -216,8 +211,8 @@ If you use EEMT in your research, please cite:
 ## 🆘 Support
 
 - 📖 [Documentation](docs/)
-- 🐛 [Issue Tracker](https://github.com/cyverse-gis/eemt/issues)
-- 💬 [Discussions](https://github.com/cyverse-gis/eemt/discussions)
+- 🐛 [Issue Tracker](https://github.com/tyson-swetnam/eemt/issues)
+- 💬 [Discussions](https://github.com/tyson-swetnam/eemt/discussions)
 - 📧 Email: [tswetnam@cyverse.org](mailto:tswetnam@cyverse.org)
 
 ---

--- a/docker/kubernetes/README.md
+++ b/docker/kubernetes/README.md
@@ -26,7 +26,7 @@ The EEMT Kubernetes deployment provides:
 
 ```bash
 # Clone the repository
-git clone https://github.com/cyverse-gis/eemt.git
+git clone https://github.com/tyson-swetnam/eemt.git
 cd eemt/docker/kubernetes
 
 # Create namespace and basic resources
@@ -581,4 +581,4 @@ For issues with Kubernetes deployment:
 - Review logs and events
 - Check cluster resource availability
 - Verify configuration values
-- Open an issue at https://github.com/cyverse-gis/eemt/issues
+- Open an issue at https://github.com/tyson-swetnam/eemt/issues

--- a/docs/about/publications.md
+++ b/docs/about/publications.md
@@ -98,12 +98,12 @@ The EEMT framework has been applied across multiple Critical Zone Observatory si
 When using the EEMT software framework, please cite:
 
 ```bibtex
-@software{eemt_framework_2025,
+@software{eemt_framework_2026,
   title = {EEMT: Effective Energy and Mass Transfer Calculation Framework},
   author = {Swetnam, Tyson L. and Rasmussen, Craig and Pelletier, Jon D.},
-  year = {2025},
+  year = {2026},
   url = {https://github.com/tyson-swetnam/eemt},
-  version = {2025.1},
+  version = {2026.1},
   doi = {10.5281/zenodo.XXXXXX}
 }
 ```

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -225,8 +225,8 @@ For API support:
 
 1. Check the [FAQ](../about/index.md#api-faq)
 2. Review [Examples](../examples/index.md)
-3. Post on [Discussions](https://github.com/cyverse-gis/eemt/discussions)
-4. Report [Issues](https://github.com/cyverse-gis/eemt/issues)
+3. Post on [Discussions](https://github.com/tyson-swetnam/eemt/discussions)
+4. Report [Issues](https://github.com/tyson-swetnam/eemt/issues)
 
 ---
 

--- a/docs/api/web-interface.md
+++ b/docs/api/web-interface.md
@@ -20,7 +20,7 @@ The easiest way to deploy EEMT is using Docker Compose, which handles all depend
 
 ```bash
 # Clone repository
-git clone https://github.com/cyverse-gis/eemt.git
+git clone https://github.com/tyson-swetnam/eemt.git
 cd eemt
 
 # Start local mode (web interface + single worker)
@@ -250,7 +250,7 @@ graph TB
 Contains all scientific computing dependencies:
 - **GRASS GIS 8.4+**: With r.sun extensions for solar modeling
 - **CCTools 7.8.2**: Makeflow + Work Queue for distributed processing
-- **Python 3.12**: Complete geospatial environment with scientific libraries
+- **Python 3.11**: Complete geospatial environment with scientific libraries
 - **GDAL 3.11**: Modern geospatial data access and format support
 - **Workflow Scripts**: Container entry points and scientific computing utilities
 
@@ -509,6 +509,3 @@ Cloud integration examples:
 
 - **Kubernetes**: Container orchestration with persistent volumes
 - **AWS/GCP/Azure**: VM clusters with shared storage
-- **Singularity**: HPC container deployment
-
-See [PLAN.md](../../PLAN.md) for complete modernization roadmap.

--- a/docs/development/setup.md
+++ b/docs/development/setup.md
@@ -13,7 +13,7 @@ This guide helps you set up a complete development environment for contributing 
 ### Required Software
 
 - **Git**: Version control (2.30+)
-- **Python**: 3.12 or later
+- **Python**: 3.11
 - **Docker**: 20.10+ and Docker Compose 2.0+
 - **Make**: Build automation
 - **VS Code** or **PyCharm**: Recommended IDEs
@@ -35,7 +35,7 @@ git clone https://github.com/YOUR_USERNAME/eemt.git
 cd eemt
 
 # Add upstream remote
-git remote add upstream https://github.com/cyverse-gis/eemt.git
+git remote add upstream https://github.com/tyson-swetnam/eemt.git
 
 # Check out development branch
 git checkout 2020_update
@@ -469,7 +469,7 @@ repos:
     rev: 23.7.0
     hooks:
       - id: black
-        language_version: python3.12
+        language_version: python3.11
 
   - repo: https://github.com/pycqa/isort
     rev: 5.12.0
@@ -691,8 +691,8 @@ Follow these guidelines:
 
 ### Getting Help
 
-- Check [existing issues](https://github.com/cyverse-gis/eemt/issues)
-- Ask in [discussions](https://github.com/cyverse-gis/eemt/discussions)
+- Check [existing issues](https://github.com/tyson-swetnam/eemt/issues)
+- Ask in [discussions](https://github.com/tyson-swetnam/eemt/discussions)
 - Review [contribution guidelines](contributing.md)
 
 ---

--- a/docs/distributed-deployment/index.md
+++ b/docs/distributed-deployment/index.md
@@ -99,7 +99,7 @@ graph TB
 - **Software**:
   - Docker or Podman
   - CCTools (Makeflow + Work Queue)
-  - Python 3.8+
+  - Python 3.11+
 
 ### Worker Node Requirements
 
@@ -109,7 +109,7 @@ graph TB
 - **Disk**: 50GB+ temporary storage (configurable)
 - **Network**: Access to master node
 - **Software**:
-  - Docker/Podman OR Singularity/Apptainer
+  - Docker/Podman
   - CCTools work_queue_worker
   - Optional: EEMT container image (for offline environments)
 
@@ -123,7 +123,7 @@ The easiest way to deploy a distributed EEMT cluster:
 
 ```bash
 # Clone repository
-git clone https://github.com/cyverse-gis/eemt.git
+git clone https://github.com/tyson-swetnam/eemt.git
 cd eemt
 
 # Start distributed cluster (master + workers)
@@ -236,7 +236,7 @@ sudo usermod -aG docker $USER
 
 ```bash
 # Clone repository
-git clone https://github.com/cyverse-gis/eemt.git
+git clone https://github.com/tyson-swetnam/eemt.git
 cd eemt
 
 # Build containers
@@ -446,37 +446,6 @@ docker run --rm \
     --cores $SLURM_CPUS_PER_TASK \
     --memory ${SLURM_MEM_PER_NODE}M \
     --work-dir /tmp/eemt-worker-$SLURM_JOB_ID
-```
-
-#### Option 2: Singularity Workers (for HPC without Docker)
-
-Create `eemt-singularity-worker.sbatch`:
-
-```bash
-#!/bin/bash
-#SBATCH --job-name=eemt-singularity-worker
-#SBATCH --nodes=1
-#SBATCH --cpus-per-task=8
-#SBATCH --mem=32GB
-#SBATCH --time=4:00:00
-
-# Load Singularity
-module load singularity/3.8
-
-# Convert Docker image to Singularity (one-time)
-# singularity pull eemt-ubuntu24.04.sif docker://eemt:ubuntu24.04
-
-# Start worker
-singularity exec \
-  --bind $TMPDIR:/tmp \
-  --env MASTER_HOST=$MASTER_HOST \
-  --env MASTER_PORT=$MASTER_PORT \
-  eemt-ubuntu24.04.sif \
-  python /scripts/start-worker.py \
-    --master-host $MASTER_HOST \
-    --master-port $MASTER_PORT \
-    --cores $SLURM_CPUS_PER_TASK \
-    --memory ${SLURM_MEM_PER_NODE}M
 ```
 
 #### Submit Multiple Workers

--- a/docs/getting-started/docker-deployment.md
+++ b/docs/getting-started/docker-deployment.md
@@ -83,7 +83,7 @@ docker compose version
 ### 1. Clone Repository
 
 ```bash
-git clone https://github.com/cyverse-gis/eemt.git
+git clone https://github.com/tyson-swetnam/eemt.git
 cd eemt
 ```
 

--- a/docs/infrastructure/container-architecture.md
+++ b/docs/infrastructure/container-architecture.md
@@ -34,7 +34,7 @@ graph TD
 
 **Key Components**:
 - Ubuntu 24.04 LTS base operating system
-- Python 3.12 with Miniconda environment management
+- Python 3.11 with Miniconda environment management
 - GDAL 3.11+ with complete geospatial stack
 - GRASS GIS 8.4+ compiled with EEMT extensions
 - CCTools 7.8.2 (Makeflow + Work Queue)

--- a/docs/infrastructure/index.md
+++ b/docs/infrastructure/index.md
@@ -357,7 +357,7 @@ docker volume inspect <volume_name>
 
 ## Support Resources
 
-- [GitHub Issues](https://github.com/cyverse-gis/eemt/issues)
-- [Discussion Forum](https://github.com/cyverse-gis/eemt/discussions)
+- [GitHub Issues](https://github.com/tyson-swetnam/eemt/issues)
+- [Discussion Forum](https://github.com/tyson-swetnam/eemt/discussions)
 - [Container Registry](https://hub.docker.com/r/eemt/ubuntu24.04)
 - [Documentation](https://tyson-swetnam.github.io/eemt/)

--- a/docs/installation/docker.md
+++ b/docs/installation/docker.md
@@ -83,7 +83,7 @@ docker compose version
 ### 1. Clone Repository
 
 ```bash
-git clone https://github.com/cyverse-gis/eemt.git
+git clone https://github.com/tyson-swetnam/eemt.git
 cd eemt
 ```
 

--- a/docs/installation/index.md
+++ b/docs/installation/index.md
@@ -20,7 +20,7 @@ The containerized approach provides the most reliable and reproducible installat
 Direct installation on your system for development or customization:
 - **Advantages**: Full control, easier debugging, native performance
 - **Best for**: Developers, HPC environments, custom integrations
-- **Requirements**: Python 3.12+, GRASS GIS 8.4+, GDAL 3.8+
+- **Requirements**: Python 3.11, GRASS GIS 8.4+, GDAL 3.8+
 
 ### 📋 [Requirements & Dependencies](requirements.md)
 Detailed list of all software dependencies and system requirements:
@@ -42,7 +42,7 @@ For most users, we recommend the Docker deployment:
 
 ```bash
 # Clone the repository
-git clone https://github.com/cyverse-gis/eemt.git
+git clone https://github.com/tyson-swetnam/eemt.git
 cd eemt
 
 # Start with Docker Compose
@@ -86,15 +86,15 @@ After successful installation:
 1. Review the [Quick Start Guide](../workflows/quick-start.md) for your first analysis
 2. Explore [Example Workflows](../examples/index.md) for real-world applications
 3. Check the [API Documentation](../api/index.md) for detailed usage
-4. Join our [community forum](https://github.com/cyverse-gis/eemt/discussions) for support
+4. Join our [community forum](https://github.com/tyson-swetnam/eemt/discussions) for support
 
 ## Support
 
 If you encounter issues during installation:
 
 1. Check the [Troubleshooting Guide](troubleshooting.md)
-2. Search [existing issues](https://github.com/cyverse-gis/eemt/issues)
-3. Create a [new issue](https://github.com/cyverse-gis/eemt/issues/new) with:
+2. Search [existing issues](https://github.com/tyson-swetnam/eemt/issues)
+3. Create a [new issue](https://github.com/tyson-swetnam/eemt/issues/new) with:
    - Your operating system and version
    - Installation method attempted
    - Complete error messages

--- a/docs/installation/manual.md
+++ b/docs/installation/manual.md
@@ -27,7 +27,7 @@ This guide provides instructions for manually installing EEMT and its dependenci
 
 ### 1. Python Environment
 
-EEMT requires Python 3.12 or later:
+EEMT requires Python 3.11:
 
 ```bash
 # Check Python version
@@ -35,13 +35,13 @@ python3 --version
 
 # Ubuntu/Debian
 sudo apt update
-sudo apt install python3.12 python3.12-venv python3.12-dev
+sudo apt install python3.11 python3.11-venv python3.11-dev
 
 # macOS (via Homebrew)
-brew install python@3.12
+brew install python@3.11
 
 # CentOS/RHEL
-sudo yum install python3.12 python3.12-devel
+sudo yum install python3.11 python3.11-devel
 ```
 
 ### 2. GRASS GIS Installation
@@ -130,7 +130,7 @@ work_queue_status --version
 ### 1. Clone Repository
 
 ```bash
-git clone https://github.com/cyverse-gis/eemt.git
+git clone https://github.com/tyson-swetnam/eemt.git
 cd eemt
 ```
 
@@ -347,9 +347,9 @@ chmod +x eemt/eemt/run-workflow
 If you encounter issues:
 
 1. Check the [FAQ](../about/index.md#faq)
-2. Search [GitHub Issues](https://github.com/cyverse-gis/eemt/issues)
-3. Post on [Discussions](https://github.com/cyverse-gis/eemt/discussions)
-4. Create a [new issue](https://github.com/cyverse-gis/eemt/issues/new) with:
+2. Search [GitHub Issues](https://github.com/tyson-swetnam/eemt/issues)
+3. Post on [Discussions](https://github.com/tyson-swetnam/eemt/discussions)
+4. Create a [new issue](https://github.com/tyson-swetnam/eemt/issues/new) with:
    - System information (OS, versions)
    - Complete error messages
    - Steps to reproduce

--- a/docs/installation/requirements.md
+++ b/docs/installation/requirements.md
@@ -48,7 +48,7 @@ This document provides comprehensive details about all hardware requirements, so
 
 | Package | Minimum Version | Purpose |
 |---------|----------------|---------|
-| **Python** | 3.10 | 3.12+ recommended |
+| **Python** | 3.10 | 3.11 recommended |
 | **numpy** | 1.22 | Numerical arrays |
 | **pandas** | 1.5 | Data manipulation |
 | **xarray** | 2023.1 | NetCDF/climate data |
@@ -117,7 +117,7 @@ sudo dnf install [packages]
 **Package Manager**:
 ```bash
 # Homebrew installation
-brew install grass gdal python@3.12
+brew install grass gdal python@3.11
 ```
 
 ### Windows
@@ -287,7 +287,7 @@ services:
 ```bash
 module load grass/8.4
 module load gdal/3.8
-module load python/3.12
+module load python/3.11
 ```
 
 ## Verification Commands

--- a/docs/installation/troubleshooting.md
+++ b/docs/installation/troubleshooting.md
@@ -179,23 +179,23 @@ chcon -Rt svirt_sandbox_file_t ./data
 
 **Symptoms**:
 ```
-ERROR: This package requires Python >=3.12
+ERROR: This package requires Python >=3.11
 ```
 
 **Solutions**:
 
-1. **Install Python 3.12**:
+1. **Install Python 3.11**:
 ```bash
 # Ubuntu/Debian
-sudo apt install python3.12 python3.12-venv
+sudo apt install python3.11 python3.11-venv
 
 # macOS
-brew install python@3.12
+brew install python@3.11
 
 # From source
-wget https://www.python.org/ftp/python/3.12.0/Python-3.12.0.tgz
-tar -xf Python-3.12.0.tgz
-cd Python-3.12.0
+wget https://www.python.org/ftp/python/3.11.0/Python-3.11.0.tgz
+tar -xf Python-3.11.0.tgz
+cd Python-3.11.0
 ./configure --enable-optimizations
 make -j $(nproc)
 sudo make altinstall
@@ -206,9 +206,9 @@ sudo make altinstall
 # Install pyenv
 curl https://pyenv.run | bash
 
-# Install Python 3.12
-pyenv install 3.12.0
-pyenv local 3.12.0
+# Install Python 3.11
+pyenv install 3.11.0
+pyenv local 3.11.0
 ```
 
 ### GRASS GIS Not Found
@@ -611,7 +611,7 @@ If these solutions don't resolve your issue:
    ```
 
 2. **Search Existing Issues**:
-   - [GitHub Issues](https://github.com/cyverse-gis/eemt/issues)
+   - [GitHub Issues](https://github.com/tyson-swetnam/eemt/issues)
    - [Stack Overflow](https://stackoverflow.com/questions/tagged/grass-gis)
 
 3. **Create New Issue** with:
@@ -621,7 +621,7 @@ If these solutions don't resolve your issue:
    - Installation method attempted
 
 4. **Community Support**:
-   - [GitHub Discussions](https://github.com/cyverse-gis/eemt/discussions)
+   - [GitHub Discussions](https://github.com/tyson-swetnam/eemt/discussions)
    - [GRASS GIS Mailing List](https://lists.osgeo.org/mailman/listinfo/grass-user)
 
 ---

--- a/docs/license.md
+++ b/docs/license.md
@@ -6,30 +6,38 @@ title: License
 
 ## Software License
 
-The EEMT software framework is released under the **MIT License**.
+The EEMT software framework is released under the **BSD 3-Clause License**.
 
 ```
-MIT License
+BSD 3-Clause License
 
-Copyright (c) 2025 Tyson L. Swetnam and contributors
+Copyright (c) 2019, Tyson Lee Swetnam
+All rights reserved.
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ```
 
 ## Documentation License
@@ -75,12 +83,12 @@ If you use EEMT in your research, please cite the appropriate methodological pap
 
 ### Software Citation
 ```bibtex
-@software{eemt_software_2025,
+@software{eemt_software_2026,
   title={EEMT: Effective Energy and Mass Transfer Calculation Framework},
   author={Swetnam, Tyson L. and Rasmussen, Craig and Pelletier, Jon D.},
-  year={2025},
+  year={2026},
   url={https://github.com/tyson-swetnam/eemt},
-  version={2025.1}
+  version={2026.1}
 }
 ```
 
@@ -99,6 +107,6 @@ Various open source licenses (BSD, MIT, Apache 2.0)
 
 ## Contributing
 
-By contributing to this project, you agree that your contributions will be licensed under the same terms as the project (MIT License for code, CC BY 4.0 for documentation).
+By contributing to this project, you agree that your contributions will be licensed under the same terms as the project (BSD 3-Clause License for code, CC BY 4.0 for documentation).
 
 See [Development Guide](development/index.md) for more information.

--- a/docs/web-interface/index.md
+++ b/docs/web-interface/index.md
@@ -20,7 +20,7 @@ The easiest way to deploy EEMT is using Docker Compose, which handles all depend
 
 ```bash
 # Clone repository
-git clone https://github.com/cyverse-gis/eemt.git
+git clone https://github.com/tyson-swetnam/eemt.git
 cd eemt
 
 # Start local mode (web interface + single worker)
@@ -250,7 +250,7 @@ graph TB
 Contains all scientific computing dependencies:
 - **GRASS GIS 8.4+**: With r.sun extensions for solar modeling
 - **CCTools 7.8.2**: Makeflow + Work Queue for distributed processing
-- **Python 3.12**: Complete geospatial environment with scientific libraries
+- **Python 3.11**: Complete geospatial environment with scientific libraries
 - **GDAL 3.11**: Modern geospatial data access and format support
 - **Workflow Scripts**: Container entry points and scientific computing utilities
 
@@ -509,9 +509,6 @@ Cloud integration examples:
 
 - **Kubernetes**: Container orchestration with persistent volumes
 - **AWS/GCP/Azure**: VM clusters with shared storage
-- **Singularity**: HPC container deployment
-
-See [PLAN.md](../../PLAN.md) for complete modernization roadmap.
 
 ## Job Data Management
 

--- a/docs/workflows/quick-start.md
+++ b/docs/workflows/quick-start.md
@@ -24,7 +24,7 @@ The fastest way to get started is using Docker Compose:
 
 ```bash
 # Clone the repository
-git clone https://github.com/cyverse-gis/eemt.git
+git clone https://github.com/tyson-swetnam/eemt.git
 cd eemt
 
 # Start the EEMT web interface
@@ -344,7 +344,7 @@ curl -X POST http://127.0.0.1:5000/api/submit-job \
 ### Resources
 
 - **Documentation**: http://127.0.0.1:8000 (when running with `--profile docs`)
-- **GitHub Issues**: https://github.com/cyverse-gis/eemt/issues
+- **GitHub Issues**: https://github.com/tyson-swetnam/eemt/issues
 - **Algorithm Details**: See [Solar Radiation Algorithms](../algorithms/solar-radiation.md)
 - **API Reference**: See [Web Interface API](../web-interface/api-reference.md)
 

--- a/web-interface/README.md
+++ b/web-interface/README.md
@@ -374,8 +374,6 @@ This local interface serves as the foundation for:
 - **OSG Mode**: Integrate with HTCondor job submission
 - **Cloud Mode**: Deploy on cloud infrastructure with persistent storage
 
-See `../PLAN.md` for the complete modernization roadmap.
-
 ## License
 
 Part of the EEMT Algorithm Suite. See main project LICENSE for details.

--- a/zensical.toml
+++ b/zensical.toml
@@ -7,7 +7,7 @@ site_description = "EEMT: An open source framework for quantifying energy and ma
 site_author = "Tyson L. Swetnam"
 site_url = "https://tyson-swetnam.github.io/eemt/"
 docs_dir = "docs"
-copyright = "Copyright &copy; 2025 Tyson L. Swetnam"
+copyright = "Copyright &copy; 2026 Tyson L. Swetnam"
 nav = [
     { "Home" = [
         "index.md",
@@ -78,9 +78,7 @@ nav = [
     ]},
     { "Development" = [
         { "Overview" = "development/index.md" },
-        { "Setup" = "development/setup.md" },
-        { "Modernization Plan" = "PLAN.md" },
-        { "Phase 1" = "PHASE1_IMPLEMENTATION.md" }
+        { "Setup" = "development/setup.md" }
     ]},
     { "About" = [
         "about/index.md",


### PR DESCRIPTION
Fix Python version references (3.12 → 3.11), replace cyverse-gis/eemt URLs with tyson-swetnam/eemt, correct license from MIT/Apache to BSD 3-Clause (matching LICENSE file), remove Singularity references and dead links to PLAN.md/RELEASE_NOTES.md, update copyright and citation years to 2026, and remove stale nav entries from zensical.toml.