### PR TITLE
FIX: Remove erroneous ../ prefix from raw HTML asset paths in energetics docs

### DIFF
--- a/docs/energetics-figures.md
+++ b/docs/energetics-figures.md
@@ -12,7 +12,7 @@ Figures from the Gordon Gulch watershed analysis. All data derived from USGS 3DE
 ## Analytical Workflow
 
 <figure>
-  <img src="../assets/images/energetics/fig07_workflow.svg" alt="Analytical workflow from LiDAR point cloud to landscape energy" width="100%">
+  <img src="assets/images/energetics/fig07_workflow.svg" alt="Analytical workflow from LiDAR point cloud to landscape energy" width="100%">
   <figcaption><strong>Figure 7.</strong> Sequential mass-energy transformation pipeline. Raw LiDAR returns (99 million points) are processed to a canopy height model, segmented into individual trees, converted to biomass via allometric equations, and scaled to energy content via higher heating values.</figcaption>
 </figure>
 
@@ -21,7 +21,7 @@ Figures from the Gordon Gulch watershed analysis. All data derived from USGS 3DE
 ## Study Area
 
 <figure>
-  <img src="../assets/images/energetics/fig01_study_area.svg" alt="Gordon Gulch DEM with hillshade" width="100%">
+  <img src="assets/images/energetics/fig01_study_area.svg" alt="Gordon Gulch DEM with hillshade" width="100%">
   <figcaption><strong>Figure 1.</strong> Gordon Gulch watershed, Arapahoe and Roosevelt National Forest, CO. Elevation ranges from 2,376 to 2,799 m across the 2.6 km² study area. 10 m DEM with analytical hillshade (azimuth 315°, altitude 45°).</figcaption>
 </figure>
 
@@ -30,7 +30,7 @@ Figures from the Gordon Gulch watershed analysis. All data derived from USGS 3DE
 ## Canopy Height Model
 
 <figure>
-  <img src="../assets/images/energetics/fig02_chm.svg" alt="0.5m Canopy Height Model" width="100%">
+  <img src="assets/images/energetics/fig02_chm.svg" alt="0.5m Canopy Height Model" width="100%">
   <figcaption><strong>Figure 2.</strong> Canopy Height Model at 0.5 m resolution, derived from 3DEP DRCOG 2020 LiDAR. CHM = DSM (maximum return) minus DTM (mean ground return), with 3×3 pit filling applied to both surfaces. Maximum canopy height is 32.5 m; 53% of the landscape has canopy exceeding 2 m.</figcaption>
 </figure>
 
@@ -39,7 +39,7 @@ Figures from the Gordon Gulch watershed analysis. All data derived from USGS 3DE
 ## Tree Census
 
 <figure>
-  <img src="../assets/images/energetics/fig03_tree_dimensions.svg" alt="Tree height and biomass distributions with summary statistics" width="100%">
+  <img src="assets/images/energetics/fig03_tree_dimensions.svg" alt="Tree height and biomass distributions with summary statistics" width="100%">
   <figcaption><strong>Figure 3.</strong> Structural dimensions of 253,476 segmented trees. <strong>(a)</strong> Height distribution showing modal height near 8 m with a right tail to 32 m. <strong>(b)</strong> Aboveground biomass on a log scale, reflecting the power-law allometric relationship. <strong>(c)</strong> Census summary statistics.</figcaption>
 </figure>
 
@@ -48,7 +48,7 @@ Figures from the Gordon Gulch watershed analysis. All data derived from USGS 3DE
 ## Individual Tree Detection
 
 <figure>
-  <img src="../assets/images/energetics/fig08_detail_view.svg" alt="200m detail view showing individual tree detections on CHM" width="80%" style="display: block; margin: 0 auto;">
+  <img src="assets/images/energetics/fig08_detail_view.svg" alt="200m detail view showing individual tree detections on CHM" width="80%" style="display: block; margin: 0 auto;">
   <figcaption><strong>Figure 8.</strong> Detail view (200 × 200 m) of individual tree detections overlaid on the CHM. Circles mark detected tree tops, sized proportionally to tree height. The variable-window local maxima algorithm adapts search radius to expected crown size at each height class.</figcaption>
 </figure>
 
@@ -57,7 +57,7 @@ Figures from the Gordon Gulch watershed analysis. All data derived from USGS 3DE
 ## Allometric Transformations
 
 <figure>
-  <img src="../assets/images/energetics/fig05_transformations.svg" alt="Height to crown, dimensions to biomass, biomass to energy transformations" width="100%">
+  <img src="assets/images/energetics/fig05_transformations.svg" alt="Height to crown, dimensions to biomass, biomass to energy transformations" width="100%">
   <figcaption><strong>Figure 5.</strong> Sequential scalar transformations from tree dimensions to energy content. <strong>(a)</strong> Height–crown diameter allometry (CD = 1.2·H<sup>0.6</sup>). <strong>(b)</strong> Dimensional product to biomass via the Jucker et al. (2017) gymnosperm model. <strong>(c)</strong> Linear biomass-to-energy conversion at 20.25 MJ kg<sup>−1</sup> (mean HHV for <em>Pinus</em> spp.).</figcaption>
 </figure>
 
@@ -66,7 +66,7 @@ Figures from the Gordon Gulch watershed analysis. All data derived from USGS 3DE
 ## Landscape Energy Field
 
 <figure>
-  <img src="../assets/images/energetics/fig04_energy_field.svg" alt="Per-tree energy content mapped across the landscape" width="100%">
+  <img src="assets/images/energetics/fig04_energy_field.svg" alt="Per-tree energy content mapped across the landscape" width="100%">
   <figcaption><strong>Figure 4.</strong> Landscape energy field showing the energy content (MJ) of each segmented tree. The spatial pattern reflects both tree density and size structure, with higher energy concentrations in mature forest stands on north-facing slopes. Total landscape energy: 5.82 × 10<sup>14</sup> J across 2.6 km².</figcaption>
 </figure>
 
@@ -75,7 +75,7 @@ Figures from the Gordon Gulch watershed analysis. All data derived from USGS 3DE
 ## Density Maps
 
 <figure>
-  <img src="../assets/images/energetics/fig06_density_maps.svg" alt="Tree density and energy density at 10m resolution" width="100%">
+  <img src="assets/images/energetics/fig06_density_maps.svg" alt="Tree density and energy density at 10m resolution" width="100%">
   <figcaption><strong>Figure 6.</strong> Spatial density distributions aggregated to 10 m grid cells. <strong>(a)</strong> Tree density (trees per 100 m²) reveals forest structure patterns including openings and dense stands. <strong>(b)</strong> Energy density (MJ ha<sup>−1</sup>) integrates both tree count and individual tree size, showing how landscape energy storage varies with topographic position.</figcaption>
 </figure>
 

--- a/docs/energetics-interactive.md
+++ b/docs/energetics-interactive.md
@@ -9,14 +9,14 @@ Explore the Gordon Gulch landscape energetics dataset interactively. The map dis
 
 <div style="position: relative; width: 100%; height: 0; padding-bottom: 75%; margin: 1em 0;">
   <iframe
-    src="../energetics-map.html"
+    src="energetics-map.html"
     style="position: absolute; top: 0; left: 0; width: 100%; height: 100%; border: 1px solid #ddd;"
     loading="lazy"
     allowfullscreen>
   </iframe>
 </div>
 
-<a href="../energetics-map.html" target="_blank" style="font-size: 0.9em;">Open full-screen map</a>
+<a href="energetics-map.html" target="_blank" style="font-size: 0.9em;">Open full-screen map</a>
 
 ## Map Layers
 


### PR DESCRIPTION
Zensical rewrites relative URLs in raw HTML img/iframe/href attributes by
prepending depth-aware ../ segments based on the rendered page's nesting.
Source paths are therefore interpreted relative to the docs root, not the
.md file's location. Previous commits a2e2b14 and 3f8b36c manually added
../ prefixes, causing Zensical to emit doubled ../../ paths that resolved
one level above the site root (404).

- docs/energetics-figures.md: 8 figure paths now use assets/images/...
  rendered as ../assets/images/... at site/energetics-figures/index.html
- docs/energetics-interactive.md: iframe src and link href now use
  energetics-map.html, rendered as ../energetics-map.html at
  site/energetics-interactive/index.html

Verified by serving the built site locally; all 8 figures and the
embedded map return HTTP 200. No container rebuild needed (docs only).